### PR TITLE
Use the most efficient way to pass image to and from Emscripten

### DIFF
--- a/example/example.cpp
+++ b/example/example.cpp
@@ -1,14 +1,9 @@
 
 #include <iostream>
-#include <stdio.h>
-#include <fstream>
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/core/mat.hpp>
-#include <opencv2/features2d/features2d.hpp>
-#include <opencv2/highgui/highgui.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
-#include <emscripten/bind.h>
 #include <emscripten.h>
 
 using namespace std;
@@ -47,41 +42,6 @@ string type2str(int type) {
   return r;
 }
 
-string mat_to_js_string(const cv::Mat img) {
-  // Casts the pixel data of a cv::Mat object to a vector of integers and returns
-  // a string representation of that vector
-  vector<int> img_vector(img.cols * img.rows * 4);
-
-  for (int i = 0, j = 0; j < img_vector.size() - 4; i += 4, j += 4){
-    img_vector[j]     = (int)img.data[i];
-    img_vector[j + 1] = (int)img.data[i+1%4];
-    img_vector[j + 2] = (int)img.data[i+2%4];
-    img_vector[j + 3] = 255;
-  }
-
-  stringstream result;
-  copy(img_vector.begin(), img_vector.end(), ostream_iterator<int>(result, ","));
-  return (result.str()).substr(0, (result.str()).size() - 1);
-}
-
-cv::Mat js_string_to_mat(int height, int width, string img_data){
-  // Splits up a ',' delimited string into a vector of unsigned chars, then
-  // creates a cv::Mat object from it, using the provided height and width
-  vector<uchar> img_vector;
-  stringstream string_stream(img_data);
-
-  int i;
-  while (string_stream >> i) {
-    img_vector.push_back(i);
-
-    if (string_stream.peek() == ',')
-        string_stream.ignore();
-  }
-
-  cv::Mat img = cv::Mat(height, width, CV_8UC4, img_vector.data());
-  return img;
-}
-
 void mat_info(const cv::Mat img) {
   // prints some mat info to the console
   cout << "--- MAT INFO ---" << endl;
@@ -91,60 +51,50 @@ void mat_info(const cv::Mat img) {
   cout << "---          ---" << endl;
 }
 
-string cv_threshold(int height, int width, string img_data) {
-  // returns a thresholded mat-string
-  cv::Mat img = js_string_to_mat(height, width, img_data);
-  cv::Mat processed_mat, output;
+extern "C"
+{
+  void EMSCRIPTEN_KEEPALIVE cv_threshold(int height, int width, char* src, char* dst)
+  {
+    cv::Mat img(height, width, CV_8UC4, src);
+    cv::Mat processed_mat;
+    cv::Mat output(height, width, CV_8UC4, dst);
 
-  cvtColor(img, processed_mat, CV_RGBA2GRAY);
-  cvtColor(processed_mat, processed_mat, CV_GRAY2RGBA);
-  threshold(processed_mat, output, 97, 255, 0);
+    cvtColor(img, processed_mat, CV_RGBA2GRAY);
+    cvtColor(processed_mat, processed_mat, CV_GRAY2RGBA);
+    threshold(processed_mat, output, 97, 255, 0);
+    // mat_info(output);
+  }
 
-  mat_info(output);
-  string mat_string = mat_to_js_string(output);
-  return mat_string;
-}
-
-string cv_blur(int height, int width, string img_data) {
   // returns a blurred mat-string
-  cv::Mat img = js_string_to_mat(height, width, img_data);
-  cv::Mat output;
+  void EMSCRIPTEN_KEEPALIVE cv_blur(int height, int width, char* src, char* dst)
+  {
+    cv::Mat img(height, width, CV_8UC4, src);
+    cv::Mat output(height, width, CV_8UC4, dst);
+    blur(img, output, cv::Size(16, 16));
+    // mat_info(output);
+  }
 
-  blur(img, output, cv::Size(16, 16));
+  void EMSCRIPTEN_KEEPALIVE cv_range(int height, int width, char* src, char* dst)
+  {
+    // returns a color thresholded mat-string
+    cv::Mat rgb_img, hsv_img, processed_mat, lower_hue, upper_hue, mask;
+    cv::Mat img(height, width, CV_8UC4, src);
 
-  mat_info(output);
-  string mat_string = mat_to_js_string(output);
-  return mat_string;
-}
+    cvtColor(img, rgb_img, CV_RGBA2RGB);
+    cvtColor(rgb_img, hsv_img, CV_RGB2HSV);
 
-string cv_range(int height, int width, string img_data) {
-  // returns a color thresholded mat-string
-  cv::Mat img = js_string_to_mat(height, width, img_data);
-  cv::Mat rgb_img, hsv_img, processed_mat, lower_hue, upper_hue, mask;
+    cv::inRange(hsv_img, cv::Scalar(0, 45, 120), cv::Scalar(30, 200, 255), lower_hue);
+    cv::inRange(hsv_img, cv::Scalar(150, 45, 120), cv::Scalar(180, 200, 255), upper_hue);
+    cv::addWeighted(lower_hue, 1.0, upper_hue, 1.0, 0.0, processed_mat);
 
-  cvtColor(img, rgb_img, CV_RGBA2RGB);
-  cvtColor(rgb_img, hsv_img, CV_RGB2HSV);
+    cv::Mat kernel = cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(11,11));
+    cv::erode(processed_mat, mask, kernel);
+    cv::dilate(mask, mask, kernel);
+    blur(mask, mask, cv::Size(4, 4));
 
-  cv::inRange(hsv_img, cv::Scalar(0, 45, 120), cv::Scalar(30, 200, 255), lower_hue);
-  cv::inRange(hsv_img, cv::Scalar(150, 45, 120), cv::Scalar(180, 200, 255), upper_hue);
-  cv::addWeighted(lower_hue, 1.0, upper_hue, 1.0, 0.0, processed_mat);
-
-  cv::Mat kernel = cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(11,11));
-  cv::erode(processed_mat, mask, kernel);
-  cv::dilate(mask, mask, kernel);
-  blur(mask, mask, cv::Size(4, 4));
-  // cvtColor(processed_mat, processed_rgba, CV_GRAY2RGBA);
-
-  cv::Mat output;
-  img.copyTo(output, mask);
-
-  mat_info(output);
-  string mat_string = mat_to_js_string(output);
-  return mat_string;
-}
-
-EMSCRIPTEN_BINDINGS(my_module) {
-    emscripten::function("cv_range", &cv_range);
-    emscripten::function("cv_blur", &cv_blur);
-    emscripten::function("cv_threshold", &cv_threshold);
+    cv::Mat output(height, width, CV_8UC4, dst);
+    img.copyTo(output, mask);
+    output.setTo(cv::Scalar(0,0,0,255), ~mask);
+    // mat_info(output);
+  }
 }

--- a/web_build/index.html
+++ b/web_build/index.html
@@ -53,9 +53,9 @@
 						<input type='file' id='input' name='file' /><br>
 						<input id='photo_capture' type='button' value='capture' /><br><br>
 						<p>OpenCV Methods</p>
-						<input type='button' value='threshold' onclick='canvas_operation(Module.cv_threshold)' /><br>
-						<input type='button' value='blur' onclick='canvas_operation(Module.cv_blur);' /><br>
-						<input type='button' value='color range' onclick='canvas_operation(Module.cv_range);' /><br><br><br>
+						<input type='button' value='threshold' onclick='canvas_operation(Module._cv_threshold)' /><br>
+						<input type='button' value='blur' onclick='canvas_operation(Module._cv_blur);' /><br>
+						<input type='button' value='color range' onclick='canvas_operation(Module._cv_range);' /><br><br><br>
 					</div>
 				</div>
 				<div class='col-sm-4'>
@@ -81,6 +81,18 @@
 		<script async src='cv.js'></script>
 
 	  <script>
+			function _arrayToHeap(typedArray){
+	      var numBytes = typedArray.length * typedArray.BYTES_PER_ELEMENT;
+	      var ptr = Module._malloc(numBytes);
+	      var heapBytes = Module.HEAPU8.subarray(ptr, ptr + numBytes);
+	      heapBytes.set(typedArray);
+	      return heapBytes;
+	    }
+
+	    function _freeArray(heapBytes){
+	      Module._free(heapBytes.byteOffset);
+	    }
+
 			function download() {
 				var canvas = document.getElementById('canvas2');
 				var data = canvas.toDataURL('image/jpeg');
@@ -99,20 +111,17 @@
 				dst_canvas.width = dst_data.width;
 				dst_canvas.height = dst_data.height;
 
-				var cv_data = cv_image_operation(dst_data.height, dst_data.width, String(src_data.data)).split(',').map(function(item){
-					return parseInt(item, 10);
-				});
-
-				for (var i = 0; i < dst_data.data.length; i++){
-					dst_data.data[i] = cv_data[i];
-				}
-
+				// copy canvas image to Emscripten heap
+				var heap_src = _arrayToHeap(src_data.data);
+				// Perform operation on copy, no additional conversions needed, direct pointer manipulation
+				// results will be put directly into the output param.
+				cv_image_operation(src_data.height, src_data.width, heap_src.byteOffset, heap_src.byteOffset);
+				// copy output to ImageData
+			  dst_data.data.set(heap_src);
+				// free heap memory
+				_freeArray(heap_src);
+				// put image on canvas
 				dst_context.putImageData(dst_data, 0, 0);
-			}
-
-			function append_text() {
-				var text = $('#text_input').val();
-				Module.process_appendix("/persistent_dir/file.txt", text)
 			}
 
 	    function getInput() {


### PR DESCRIPTION
The original code which works well, is **_VERY VERY_** slow.
However, it is not slow due to OpenCV, but due to the way that the images are passed to the emscriptened functions. They are first converted to strings (!!) and then these huge strings are duplicated multiple times before getting to the OpenCV functions. Returning the result duplicates this process backwards!

It is possible to copy the image data to the Emscripten heap and pass that new heap buffer via a pointer interface. This involves just a single copy in each direction, both of which are done via native TypeArray set calls and not interpreted JS.

I removed all redundant and inefficient image copying and string conversions.
The result is about **_3 orders of magnitude_** FASTER than previous version.

References:

- This SO question: [Passing a JS ArrayBuffer or TypedArray to Emscripten w/o Copying](https://stackoverflow.com/q/42434845/135862)
- [This thread](https://groups.google.com/forum/?#!starred/emscripten-discuss/CMfYljLWMvY).



Enjoy!